### PR TITLE
Increase range of random minutes by 6x

### DIFF
--- a/server.js
+++ b/server.js
@@ -98,7 +98,7 @@ var jobs = require('./config/jobs.js');
 // As there are 2 instances running, we need a random time, or two emails will be sent
 // for accounts nearing expiration. (Flag will be set by time of 2nd job execution to stop duplicate)
 var randomSecond = Math.floor(Math.random() * 60);
-var randomMin = Math.floor(Math.random() * 10);
+var randomMin = Math.floor(Math.random() * 60); //Math.random returns a number from 0 to < 1 (never will return 60)
 var jobScheduleRandom = randomSecond + " " + randomMin + " " + 
     environmentVariables.userAccountSettings.jobScheduleHour + " * * *";
 


### PR DESCRIPTION
- We had a duplicate email on saturday
- Any time less than a minute is seemingly not long enough to stop duplicates (issue appears when time between checks is <=31 seconds, and works when time between checks is > 6 minutes)