### PR TITLE
chore: update text for sign-in page

### DIFF
--- a/public/importer.css
+++ b/public/importer.css
@@ -3617,7 +3617,6 @@ x:-moz-any-link {
   -moz-osx-font-smoothing: grayscale;
   font-weight: 400;
   font-size: 16px;
-  font-size: 1rem;
   line-height: 1.25;
   color: #0b0c0c;
   padding: 15px;
@@ -3634,7 +3633,6 @@ x:-moz-any-link {
 @media (min-width: 40.0625em) {
   .govuk-inset-text {
     font-size: 19px;
-    font-size: 1.1875rem;
     line-height: 1.3157894737;
   }
 }

--- a/views/sign-in.ejs
+++ b/views/sign-in.ejs
@@ -13,7 +13,7 @@
 <%if(!signed_out && !hide_back_link){%>
 <a href="<%= back_link%>" class="back-to-previous">Back</a>
 <%}%>
-<h1 class="heading-xlarge">Sign in</h1>
+<h1 class="heading-large">Sign in</h1>
 
 <div class="column-two-thirds">
     <script>var _paq = _paq || [];</script>
@@ -54,6 +54,9 @@
 
 
     <!-- LOGIN FORM -->
+    <p>
+        <a href="/api/user/register?from=/api/user/sign-in">Create an account</a> if you do not already have one.
+    </p>
     <form action="/api/user/sign-in?_csrf=<%=_csrf%>" method="post" id="sign-in">
         <input type="hidden" name="next" value="<%= qs.next %>" />
         <div class="form-group <%if(email_error){%>error<%}%>">
@@ -72,8 +75,9 @@
 
 
     </form>
+    <section class="govuk-inset-text">
+        Your application will time out and you will have to start again if you do not enter information for 30 minutes.
+    </section>
 </div>
-    <hr>
-    <p><a href="/api/user/register?from=/api/user/sign-in">Create an account</a></p>
 
 <%- include ('partials/footer') %>


### PR DESCRIPTION
# Description

The purpose of this ticket is to update the copy on the sign-in page.

## Before
<img width="740" alt="Screenshot 2022-05-27 at 11 54 04" src="https://user-images.githubusercontent.com/1377253/170686334-90746a96-ed45-49d5-b666-4539c5e09e61.png">


## After
<img width="802" alt="Screenshot 2022-05-27 at 11 53 49" src="https://user-images.githubusercontent.com/1377253/170686342-705a5102-2e02-4242-926e-99a62da224f9.png">

