### PR TITLE
fix: allow page to redirect to eapp after sign in

### DIFF
--- a/views/sign-in.ejs
+++ b/views/sign-in.ejs
@@ -57,7 +57,7 @@
     <p>
         <a href="/api/user/register?from=/api/user/sign-in">Create an account</a> if you do not already have one.
     </p>
-    <form action="/api/user/sign-in?_csrf=<%=_csrf%>" method="post" id="sign-in">
+    <form action="/api/user/sign-in?_csrf=<%=_csrf%><% if (qs.eappid) { %>&eappid=<%= qs.eappid %><% } %>" method="post" id="sign-in">
         <input type="hidden" name="next" value="<%= qs.next %>" />
         <div class="form-group <%if(email_error){%>error<%}%>">
             <label for="email" class="form-label-bold">Email</label>


### PR DESCRIPTION
# Description

The purpose of this PR is to let the user know how to view an eApp if they are not signed in.

The issue was a user would click on the direct link to an eApp from their email after it has been legalised but, would be presented with an error because they are not logged in. This PR (with the combination of another), hopes to fix that issue.

https://user-images.githubusercontent.com/1377253/175323562-57c7b863-7651-4512-9af4-e7c208ec3a44.mp4


