### PR TITLE
FCDO-1748: Fix issue with /approve & /reject links

### DIFF
--- a/app/controllers/requestBusinessServiceAccessController.js
+++ b/app/controllers/requestBusinessServiceAccessController.js
@@ -270,6 +270,12 @@ module.exports.approve = async function(req, res) {
 
     try {
 
+        // Added this code to prevent HEAD requests triggering
+        // the logic in Production
+        if (req.method !== 'GET') {
+            return res.status(200).send('OK');
+        }
+
         let token = req.params['token']
         let userAccountMatchingToken = await findAccountMatchingToken(token)
 
@@ -396,6 +402,12 @@ module.exports.approve = async function(req, res) {
 module.exports.reject = async function(req, res) {
 
     try {
+
+        // Added this code to prevent HEAD requests triggering
+        // the logic in Production
+        if (req.method !== 'GET') {
+            return res.status(200).send('OK');
+        }
 
         async function findAccountMatchingToken(token) {
             try {


### PR DESCRIPTION
For production there appears to be both HEAD and GET requests accessing the links. This is most likely caused by Outlook verifying the links in the email.