### PR TITLE
Refactor postcodeLookup to remove trailing forward slash from API URL

### DIFF
--- a/app/controllers/addressController.js
+++ b/app/controllers/addressController.js
@@ -538,9 +538,11 @@ module.exports.deleteAddress= function(req,res) {
 
 async function postcodeLookup(normalisedPostcode) {
     const postcode = normalisedPostcode.replace(/ /g, '');
+    const url = `${envVariables.postcodeLookUpApiOptions.uri.replace(/\/$/, '')}/lookup/${postcode}`
+
     const options = {
         ...envVariables.postcodeLookUpApiOptions,
-        url: `${envVariables.postcodeLookUpApiOptions.uri}/lookup/${postcode}`
+        url
     };
 
     try {


### PR DESCRIPTION
@ConorGallagher1  discover while testing out https://github.com/UKForeignOffice/loi-address-service/pull/65,

The address lookup were working from application service but not from user services. It turns out that Express 5 in Address service was not finding the path like Express 4 did due to the config setting ending in forward slash and when concat with the remaining url it ended up having a double forward slash

This commit addresses the issue by stripping out ending forward slash in the config setting so it is now normalised .